### PR TITLE
Fix jOOQ timeout issue

### DIFF
--- a/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/api/Codec.kt
+++ b/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/api/Codec.kt
@@ -60,7 +60,7 @@ value class EventCodecRegistry(
     @Suppress("UNCHECKED_CAST")
     codecs.find(type).map { it as EventCodec<E> }
 
-  object Key : EpoqueContextKey<EventCodecRegistry>
+  companion object : EpoqueContextKey<EventCodecRegistry>
 }
 
 @JvmInline
@@ -102,5 +102,5 @@ value class CommandCodecRegistry(
 
   fun toMap(): Map<CommandType, CommandCodec<*>> = codecs.toMap()
 
-  object Key : EpoqueContextKey<CommandCodecRegistry>
+  companion object : EpoqueContextKey<CommandCodecRegistry>
 }

--- a/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/api/CommandHandler.kt
+++ b/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/api/CommandHandler.kt
@@ -20,7 +20,9 @@ interface CommandRouter : CommandProcessor {
   val commandProcessorRegistry: CommandProcessorRegistry
 
   override suspend fun process(input: CommandInput): Failable<CommandOutput> =
-    commandProcessorRegistry.find(input.type).flatMap { it.process(input) }
+    EpoqueContext.with({ add(CommandCodecRegistry, commandCodecRegistry) }) {
+      commandProcessorRegistry.find(input.type).flatMap { it.process(input) }
+    }
 
   companion object
 }

--- a/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/api/EventStore.kt
+++ b/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/api/EventStore.kt
@@ -6,7 +6,7 @@ interface TransactionContext {
   val lockOption: LockOption
   val lockedKeys: Set<JournalKey>
 
-  object Key : EpoqueContextKey<TransactionContext>
+  companion object : EpoqueContextKey<TransactionContext>
 }
 
 /** Controls how command handlers are executed for each [JournalKey] */

--- a/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/api/Values.kt
+++ b/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/api/Values.kt
@@ -1,5 +1,7 @@
 package io.github.uharaqo.epoque.api
 
+import java.time.Instant
+
 @JvmInline
 value class JournalGroupId(val unwrap: String) {
   override fun toString() = unwrap
@@ -51,9 +53,17 @@ data class CommandContext(
   val command: SerializedCommand,
   val metadata: InputMetadata,
   val options: CommandExecutorOptions,
+  val receivedTime: Instant,
 ) {
-  object Key : EpoqueContextKey<CommandContext>
+
+  companion object : EpoqueContextKey<CommandContext>
 }
+
+fun CommandContext.getElapsedTimeMillis(): Long =
+  Instant.now().toEpochMilli() - receivedTime.toEpochMilli()
+
+fun CommandContext.getRemainingTimeMillis(): Long =
+  options.timeoutMillis - getElapsedTimeMillis()
 
 data class CommandHandlerOutput<E>(
   val events: List<E>,

--- a/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/impl/CommandHandlerBuidler.kt
+++ b/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/impl/CommandHandlerBuidler.kt
@@ -1,9 +1,14 @@
 package io.github.uharaqo.epoque.impl
 
+import arrow.core.flatMap
 import arrow.core.getOrElse
 import arrow.core.raise.Raise
+import io.github.uharaqo.epoque.api.CommandCodecRegistry
+import io.github.uharaqo.epoque.api.CommandExecutorOptions
 import io.github.uharaqo.epoque.api.CommandHandler
 import io.github.uharaqo.epoque.api.CommandHandlerOutput
+import io.github.uharaqo.epoque.api.CommandInput
+import io.github.uharaqo.epoque.api.CommandType
 import io.github.uharaqo.epoque.api.EpoqueException.Cause.COMMAND_REJECTED
 import io.github.uharaqo.epoque.api.Journal
 import io.github.uharaqo.epoque.api.JournalChecker
@@ -28,20 +33,40 @@ interface CommandHandlerBuilder<C, S, E> : Raise<Throwable> {
   suspend fun exists(key: JournalKey): Boolean
 
   override fun raise(r: Throwable): Nothing = throw r
+
+  fun chain(
+    id: String,
+    command: Any,
+    options: CommandExecutorOptions = CommandExecutorOptions(),
+    metadata: Map<Any, Any> = emptyMap(),
+  ) = chain(JournalId(id), command, options, metadata)
+
+  fun chain(
+    id: JournalId,
+    command: Any,
+    options: CommandExecutorOptions = CommandExecutorOptions(),
+    metadata: Map<Any, Any> = emptyMap(),
+  )
+}
+
+fun interface CommandHandlerRuntimeEnvironmentFactory<C : Any, S, E : Any> {
+  suspend fun create(): CommandHandlerRuntimeEnvironment<C, S, E>
 }
 
 class DefaultCommandHandler<C : Any, S, E : Any>(
   private val impl: suspend CommandHandlerBuilder<C, S, E>.(C, S) -> Unit,
-  private val runtimeEnvFactory: () -> CommandHandlerRuntimeEnvironment<C, S, E>,
+  private val runtimeEnvFactory: CommandHandlerRuntimeEnvironmentFactory<C, S, E>,
 ) : CommandHandler<C, S, E> {
   override suspend fun handle(c: C, s: S): CommandHandlerOutput<E> =
-    runtimeEnvFactory().apply { impl(c, s) }.complete()
+    runtimeEnvFactory.create().apply { impl(c, s) }.complete()
 }
 
 class CommandHandlerRuntimeEnvironment<C, S, E>(
   private val journalChecker: JournalChecker,
+  private val commandCodecRegistry: CommandCodecRegistry?,
 ) : CommandHandlerBuilder<C, S, E> {
   private val events = ConcurrentLinkedQueue<E>()
+  private val chainedCommands = ConcurrentLinkedQueue<CommandInput>()
   private var metadata = mutableMapOf<Any, Any>()
 
   override fun emit(events: List<E>, metadata: Map<Any, Any>) {
@@ -50,8 +75,21 @@ class CommandHandlerRuntimeEnvironment<C, S, E>(
   }
 
   override suspend fun exists(key: JournalKey): Boolean =
-    journalChecker.journalExists(key, TransactionContext.Key.get()!!).getOrElse { throw it }
+    journalChecker.journalExists(key, TransactionContext.get()!!).getOrElse { throw it }
 
-  fun complete(): CommandHandlerOutput<E> =
-    CommandHandlerOutput(events.toList(), metadata.asOutputMetadata())
+  override fun chain(
+    id: JournalId,
+    command: Any,
+    options: CommandExecutorOptions,
+    metadata: Map<Any, Any>,
+  ) {
+    val type = CommandType.of(command::class.java)
+    val serialized =
+      commandCodecRegistry!!.find<Any>(type).flatMap { it.encode(command) }.getOrElse { throw it }
+    chainedCommands += CommandInput(id, type, serialized, metadata, options)
+  }
+
+  fun complete(): CommandHandlerOutput<E> {
+    return CommandHandlerOutput(events.toList(), metadata.asOutputMetadata())
+  }
 }

--- a/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/impl/ProjectionRegistry.kt
+++ b/epoque-core/src/main/kotlin/io/github/uharaqo/epoque/impl/ProjectionRegistry.kt
@@ -30,7 +30,7 @@ class TransactionalProjectionExecutor(
   private val projectionRegistry: ProjectionRegistry,
 ) : CallbackHandler {
   override suspend fun beforeCommit(output: CommandOutput) {
-    val tx = TransactionContext.Key.get()
+    val tx = TransactionContext.get()
       ?: throw UNKNOWN_EXCEPTION.toException(message = "Transaction not found")
 
     output.events.forEach { ve ->

--- a/epoque-db-jooq/src/test/kotlin/io/github/uharaqo/epoque/db/jooq/JooqUtil.kt
+++ b/epoque-db-jooq/src/test/kotlin/io/github/uharaqo/epoque/db/jooq/JooqUtil.kt
@@ -1,5 +1,6 @@
 package io.github.uharaqo.epoque.db.jooq
 
+import io.github.uharaqo.epoque.db.jooq.h2.H2JooqQueries
 import java.sql.DriverManager
 import org.jooq.DSLContext
 import org.jooq.JSONB

--- a/epoque-test/src/main/kotlin/io/github/uharaqo/epoque/test/EpoqueTest.kt
+++ b/epoque-test/src/main/kotlin/io/github/uharaqo/epoque/test/EpoqueTest.kt
@@ -6,9 +6,9 @@ import io.github.uharaqo.epoque.api.CommandRouter
 import io.github.uharaqo.epoque.api.EpoqueEnvironment
 import io.github.uharaqo.epoque.api.EventStore
 import io.github.uharaqo.epoque.api.LockOption.LOCK_JOURNAL
-import io.github.uharaqo.epoque.db.jooq.H2JooqQueries
 import io.github.uharaqo.epoque.db.jooq.JooqEventStore
 import io.github.uharaqo.epoque.db.jooq.TableDefinition
+import io.github.uharaqo.epoque.db.jooq.h2.H2JooqQueries
 import io.github.uharaqo.epoque.impl.CommandRouterFactory
 import io.github.uharaqo.epoque.impl.DefaultCommandRouter
 import io.github.uharaqo.epoque.impl.fromFactories

--- a/epoque-test/src/main/kotlin/io/github/uharaqo/epoque/test/impl/EpoqueTest.kt
+++ b/epoque-test/src/main/kotlin/io/github/uharaqo/epoque/test/impl/EpoqueTest.kt
@@ -46,7 +46,7 @@ class DefaultCommandTester<S, E : Any>(
     either {
       val type = CommandType.of(command::class.java)
       val commandCodec = commandRouter.commandCodecRegistry.find<Any>(type).bind()
-      val payload = commandCodec.encoder.encode(command).bind()
+      val payload = commandCodec.encode(command).bind()
       val input = CommandInput(id, type, payload, metadata)
 
       val result = runBlocking { commandRouter.process(input) }.bind()

--- a/integration-test/src/main/kotlin/io/github/uharaqo/epoque/integration/epoque/project/Spec.kt
+++ b/integration-test/src/main/kotlin/io/github/uharaqo/epoque/integration/epoque/project/Spec.kt
@@ -1,6 +1,7 @@
 package io.github.uharaqo.epoque.integration.epoque.project
 
 import io.github.uharaqo.epoque.Epoque
+import io.github.uharaqo.epoque.integration.epoque.task.CreateTask
 import io.github.uharaqo.epoque.serialization.JsonCodecFactory
 
 sealed interface Project {
@@ -21,6 +22,7 @@ val PROJECT_JOURNAL = builder.summaryFor<Project>(Project.Empty) {
 val PROJECT_COMMANDS = builder.routerFor<ProjectCommand, Project, ProjectEvent>(PROJECT_JOURNAL) {
   commandHandlerFor<CreateProject> { c, s ->
     if (s is Project.Empty) {
+      chain("Foo", CreateTask("TaskX"))
       emit(c.toProjectCreated())
     } else {
       reject("Project already exists")


### PR DESCRIPTION
Kotlin's `withTimeout {...}` uses a `Job` in a coroutineContext. It needs to be removed when a jOOQ's coroutine support is used. Reset the remaining timeout to ensure that commandHandler execution times out and the transaction gets rolled back on timeout.